### PR TITLE
chore: remove unused docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-version: "3.7"
-
-services:
-  floci:
-    image: "hectorvent/floci:latest"
-    ports:
-      - 4566:4566
-    environment:
-      - FLOCI_HOSTNAME=floci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,9 @@
 version: "3.7"
 
 services:
-  localstack:
-    image: "localstack/localstack"
+  floci:
+    image: "hectorvent/floci:latest"
     ports:
       - 4566:4566
     environment:
-      - DEBUG=1
-      - SERVICES=lambda,s3,apigateway,cloudformation
-      - LAMBDA_EXECUTOR=docker
-      - DOCKER_HOST=unix:///var/run/docker.sock
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - FLOCI_HOSTNAME=floci


### PR DESCRIPTION
## Summary
- Remove unused `docker-compose.yml` (localstack service)
- No code in the project references localstack, floci, or port 4566

## Test plan
- [x] Verify no existing workflows or scripts depend on `docker-compose.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)